### PR TITLE
Fix make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LATEXMK_OPTS = -pdf \
                -interaction=nonstopmode \
                -usepretex="\PassOptionsToPackage{draft}{graphicx}" \
                -pdflatex="pdflatex %O %S" \
-               -output-directory=build
+               -output-directory=build \
 	       -jobname=aw4null-overview
 
 .PHONY: all draft clean

--- a/src/main.tex
+++ b/src/main.tex
@@ -338,10 +338,12 @@ By proving a concept of intergration of these three layers, the project will out
 Detail the integrated pilot installation in partner workshops, including hardware setup and user interface snapshots.
 The current demonstrator consists of six primary components:
 \begin{itemize}
-  \item A laptop equipped with OmnAIView and VCDS software
+  \item A Latop
+  \item Installed OmnAIView software
+  \item Installed VCDS Software
   \item A VCDS diagnostic tool
   \item Four OmnAIScopes
-  \item Connection equipment (e.g., cables, Banana-to-BNC adapters)
+  \item Lab-Connectors (e.g., Banana-to-BNC adapters)
   \item A formal contract
   \item Instructional materials
 \end{itemize}

--- a/src/main.tex
+++ b/src/main.tex
@@ -68,10 +68,10 @@ and advanced driver-assistance features, to effectively identify the root cause 
 Design goals for these car diagnostic systems are multiple:
 \begin{itemize}
   \item Clarity and specificity of the erroneous part
-  \item Usability: easy to use correctly and hard to use incorrectly; teachability
+  \item Easy to use correctly and hard to use incorrectly
   \item Robustness against physical damage
-  \item Pricing
-  \item Costs of illformed diagnostics
+  \item Minimizing costs of acquisition and operation
+  \item Avoiding costs for illformed diagnostics
 \end{itemize}
 Since some faults can lead to degraded combustion behaviors without noticeable effects for the car’s operator, 
 some of these diagnostic systems have to be built into the car while others may reside in a sophisticated auto workshop, 


### PR DESCRIPTION
After a new line, which shall still be part of the original command, the `newline` character has to be escaped by a `\`.

Fixed it