### PR TITLE
BUG: fix where release pipline failed on pdf build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
            texlive-fonts-recommended \
            texlive-publishers \
            texlive-bibtex-extra \
+           texlive-lang-cjk \
            latexmk \
            lmodern
       - name: Build PDF (ignore latexmk errors)


### PR DESCRIPTION
- Fix bug by adding library for asian language support to the workflow file. 